### PR TITLE
Adds a top-level README for the Apache Github org

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,11 @@
+The [Apache Software Foundation](https://apache.org) (ASF) is home to more
+than [300 software projects](https://projects.apache.org), many of which
+host their code repositories in this Github org.
+
+Software in this org is released under the [Apache
+License](https://www.apache.org/licenses/LICENSE-2.0).
+
+ASF projects follow the ASF [vulnerability handling 
+process](https://apache.org/security/#vulnerability-handling).
+
+

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,3 +1,5 @@
+![The Apache Software Foundation](https://apache.org/img/asf-estd-1999-logo.jpg)
+
 The [Apache Software Foundation](https://apache.org) (ASF) is home to more
 than [300 software projects](https://projects.apache.org), many of which
 host their code repositories in this Github org.


### PR DESCRIPTION
This adds a top-level README for the Apache github org, giving basic information about the ASF, and projects contained in this org. It is my understanding that this goes in a /profile directory, rather than the top level directory, and this is the pattern that I see on numerous other top-level org repos.